### PR TITLE
docker-compose.yml - adding a %YAML 1.1

### DIFF
--- a/nifi-docker-compose/docker-compose.yml
+++ b/nifi-docker-compose/docker-compose.yml
@@ -1,3 +1,6 @@
+%YAML 1.1
+---
+
 version: '3.9'
 
 x-user: &user admin


### PR DESCRIPTION
Merge keys << are a default feature in YAML 1.1, but not in YAML 1.2 to which Yaml defaults. Adding a %YAML 1.1 directive should clear up the errors "Map keys must be unique" creating a new stack, when using docker-compose.yml with Portainer.